### PR TITLE
Removing roles directory after build.

### DIFF
--- a/playbook_builder.yaml
+++ b/playbook_builder.yaml
@@ -93,6 +93,10 @@
           shell: "losetup -d {{ rs_loop.stdout_lines[-1] }}"
           ignore_errors: yes
           when: rs_loop.stdout_lines
+        - name: Remove roles folder
+          file:
+            path: "profiles/{{ PROFILE }}/roles"
+            state: absent
     - name: Builder - Show errors from playbook
       debug:
         var: rs_playbook.stderr_lines


### PR DESCRIPTION
Removing roles after build as default is desirable:
- to be sure roles are updated during each build
- as prevention to unwanted build artifacts in CI due to relatively complex build process. (directory rights and ownership)